### PR TITLE
ci: create release on tagging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,4 +32,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          gh release create "${{ github.ref_name }}" --generate-notes --draft ||:
           gh release upload "${{ github.ref_name }}" dist/tedge-container-plugin-ui_*.zip

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+
+RELEASE_VERSION := env_var_or_default("RELEASE_VERSION", `jq -r '.version' package.json`)
+
+# Trigger a release (by creating a tag)
+release:
+    echo git tag -a "{{RELEASE_VERSION}}" -m "{{RELEASE_VERSION}}"
+    echo git push origin "{{RELEASE_VERSION}}"
+    @echo
+    @echo "Created release (tag): {{RELEASE_VERSION}}"
+    @echo


### PR DESCRIPTION
Add simple justfile to handled taggings of the repo (based on the current version in the package.json file).

This could be replaced in the future by a more npm based approach.